### PR TITLE
Pass the current path to isort, so it can find config files

### DIFF
--- a/isort_file.py
+++ b/isort_file.py
@@ -51,6 +51,7 @@ class IsortCommand(sublime_plugin.TextCommand):
         settings = self.get_settings()
         sorted_imports = SortImports(
             file_contents=this_contents,
+            settings_path=this_view.file_name(),
             **settings
         ).output
         this_view.replace(edit, self.get_region(this_view), sorted_imports)


### PR DESCRIPTION
Otherwise the path that isort is using for `settings_path` [isort.py#65](https://github.com/timothycrosley/isort/blob/develop/isort/isort.py#L65) is quite random (sometimes the project dir of the last opened project, but can also be the location of the sublime exec, depending on how you run it). Now it is able to find `.editorconfig`, `.setup.cfg`, and `.isort.cfg` in the project dir.

ps. Why do you define `get_view` and `set_view`? `TextCommand.view` should already be set to the current view by sublime
